### PR TITLE
Fixed missing dart-define parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.7] - 8 July 2022
+- Extension version update to 0.3.7
+- *Build Task* version update to "0.3.3"
+- *Build Task* fixes `dartDefine` and `dartDefineMulti` not being passed to the command
+
 ## [0.3.6] - 17 June 2022
 - Extension version update to 0.3.6
 - *Install Task* version update to "0.3.4"

--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -76,7 +76,7 @@ function main() {
             yield buildAab(flutterPath, buildName, buildNumber, debugMode, buildFlavour, entryPoint, dartDefine, dartDefineMulti, isVerbose, extraArgs);
         }
         if (target === "all" || target === "web") {
-            yield buildWeb(flutterPath, isVerbose, extraArgs);
+            yield buildWeb(flutterPath, isVerbose, extraArgs, dartDefine, dartDefineMulti);
         }
         if (target === "all"
             || target === "desktop"
@@ -86,12 +86,12 @@ function main() {
         if (target === "all"
             || target === "desktop"
             || target === "macos") {
-            yield buildDesktop(flutterPath, "macos", isVerbose, entryPoint, extraArgs);
+            yield buildDesktop(flutterPath, "macos", isVerbose, entryPoint, extraArgs, dartDefine, dartDefineMulti);
         }
         if (target === "all"
             || target === "desktop"
             || target === "linux") {
-            yield buildDesktop(flutterPath, "linux", isVerbose, entryPoint, extraArgs);
+            yield buildDesktop(flutterPath, "linux", isVerbose, entryPoint, extraArgs, dartDefine, dartDefineMulti);
         }
         task.setResult(task.TaskResult.Succeeded, "Application built");
     });

--- a/tasks/build/index.ts
+++ b/tasks/build/index.ts
@@ -109,25 +109,25 @@ async function main(): Promise<void> {
     }
 
     if (target === "all" || target === "web") {
-        await buildWeb(flutterPath, isVerbose, extraArgs);
+        await buildWeb(flutterPath, isVerbose, extraArgs, dartDefine, dartDefineMulti);
     }
 
     if (target === "all"
         || target === "desktop"
         || target === "windows") {
-        await buildDesktop(flutterPath, "windows", isVerbose, entryPoint, extraArgs, dartDefine, dartDefineMulti,);
+        await buildDesktop(flutterPath, "windows", isVerbose, entryPoint, extraArgs, dartDefine, dartDefineMulti);
     }
 
     if (target === "all"
         || target === "desktop"
         || target === "macos") {
-        await buildDesktop(flutterPath, "macos", isVerbose, entryPoint, extraArgs);
+        await buildDesktop(flutterPath, "macos", isVerbose, entryPoint, extraArgs, dartDefine, dartDefineMulti);
     }
 
     if (target === "all"
         || target === "desktop"
         || target === "linux") {
-        await buildDesktop(flutterPath, "linux", isVerbose, entryPoint, extraArgs);
+        await buildDesktop(flutterPath, "linux", isVerbose, entryPoint, extraArgs, dartDefine, dartDefineMulti);
     }
 
     task.setResult(task.TaskResult.Succeeded, "Application built");

--- a/tasks/build/task.json
+++ b/tasks/build/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 3,
-        "Patch": 2
+        "Patch": 3
     },
     "groups": [],
     "instanceNameFormat": "Flutter Build $(target)",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "flutter",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "name": "Flutter Tasks",
     "description": "Flutter extension for Azure DevOps. Install, build, analyze, command and env tasks for easier Flutter DevOps.",
     "publisher": "hey24sheep",


### PR DESCRIPTION
# Description

The `--dart-define` parameter is not passed to the build command even if `dartDefine` and `dartDefineMulti` is specified in the pipeline.

```
- task: FlutterBuild@0
  inputs:
    target: 'web'
    projectDirectory: '$(Build.SourcesDirectory)'
    dartDefine: 'k=v'
    dartDefineMulti: 'k1=v1 k2=v2'
    extraArgs: '--release --web-renderer html'
```

![FlutterBuild-v0 3 2](https://user-images.githubusercontent.com/36004576/177927180-d629a06e-430f-4bc7-8c4c-0a8a6a4eaffe.PNG)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The same pipeline is run with the committed code, and the `--dart-define` parameters are added to the build command.

![FlutterBuild-v0 3 3](https://user-images.githubusercontent.com/36004576/177927880-cacd1abf-b043-433b-9174-ed794e25a71e.PNG)