### PR TITLE
Fix: Monitor STDOUT for initiation message

### DIFF
--- a/tasks/test/index.ts
+++ b/tasks/test/index.ts
@@ -108,11 +108,11 @@ async function runTests(flutter: string,
     };
 
     testRunner.on('stdout', line => {
-        const testSuiteRegex = /\s*\d\d:\d\d (\+\d+)?(\s+\-\d+)?:\s*loading\s*(.*\.dart)\s*/;
-        let loadingMatch = testSuiteRegex.exec(line);
-        if (loadingMatch) {
+        const testSuiteRegex = /\s*\d\d:\d\d (\+\d+)?(\s+\-\d+)?:\s*(?<title>.*\.dart):\s*\(setUpAll\)/;
+        let setUpMatch = testSuiteRegex.exec(line);
+        if (setUpMatch) {
             var newSuite = {
-                title: path.basename(loadingMatch[3], ".dart"),
+                title: path.basename(setUpMatch.groups.title, ".dart"),
                 isSuccess: false,
                 succeeded: 0,
                 failed: 0,


### PR DESCRIPTION
Blind, but possible fix for #83, code was monitoring STDOUT for an initiation message ("loading") which never arrives on Windows platforms. Instead, monitor for "setUpAll" message which as been confirmed to occur on Windows, Linux and MacOS